### PR TITLE
This commit introduces the following:

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -1,0 +1,27 @@
+name: Build Book
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install Pandoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra
+
+      - name: Build PDF
+        run: make
+
+      - name: Upload PDF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: book
+          path: book.pdf

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+SHELL := /bin/bash
+SOURCES = $(wildcard src/*.md)
+OUTPUT_FILE = book.pdf
+
+# Default target
+all: $(OUTPUT_FILE)
+
+# Rule to build the PDF
+$(OUTPUT_FILE): $(SOURCES) pandoc.yaml
+	pandoc $(SOURCES) -o $(OUTPUT_FILE) --defaults pandoc.yaml
+
+# Phony target for cleaning up build artifacts
+clean:
+	rm -f $(OUTPUT_FILE)
+
+.PHONY: all clean

--- a/pandoc.yaml
+++ b/pandoc.yaml
@@ -1,0 +1,9 @@
+---
+title: "My Book"
+author: "Jules Verne"
+date: "2024-07-26"
+documentclass: book
+toc: true
+toc-depth: 2
+highlight-style: tango
+---

--- a/src/chapter1.md
+++ b/src/chapter1.md
@@ -1,0 +1,2 @@
+# Chapter 1
+This is the first chapter.

--- a/src/chapter2.md
+++ b/src/chapter2.md
@@ -1,0 +1,2 @@
+# Chapter 2
+This is the second chapter.


### PR DESCRIPTION
- Makefile: Converts Markdown files from the 'src' directory into 'book.pdf' using Pandoc.
- pandoc.yaml: Configuration file for Pandoc, specifying metadata like title, author, TOC depth, and syntax highlighting.
- src/ directory: Contains sample Markdown chapter files (chapter1.md, chapter2.md).
- .github/workflows/build-book.yml: A GitHub Actions workflow that:
    - Triggers on pushes to the main branch.
    - Installs Pandoc and necessary LaTeX dependencies.
    - Builds 'book.pdf' using the Makefile.
    - Uploads 'book.pdf' as a build artifact.

This setup automates the creation of a PDF book from Markdown sources.